### PR TITLE
Ensure proper page is selected after changing score layout

### DIFF
--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -2970,6 +2970,8 @@ MainWindow::alignmentReadyForReview()
 
     m_paneStack->setCurrentLayer(onsetsPane, onsetsLayer);
 
+    m_alignAcceptReject->setFixedSize(m_alignCommands->size());
+    
     m_alignCommands->hide();
     m_alignAcceptReject->show();
 

--- a/main/ScoreWidget.h
+++ b/main/ScoreWidget.h
@@ -244,6 +244,8 @@ private:
     QRectF getHighlightRectFor(const EventData &);
     
     void findSystemExtents(QByteArray, std::shared_ptr<QSvgRenderer>);
+
+    bool reloadScoreFile(QString &error);
     
     QTransform m_widgetToPage;
     QTransform m_pageToWidget;


### PR DESCRIPTION
The score is now reloaded at the page containing the highlighted event.

If no event is highlighted, the first event on the previously-current page is used.

Also merge in the last changes from the piano-precision repo (about maintaining the proper width for the score widget).
