### PR TITLE
Support for additional audio files

### DIFF
--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -5774,6 +5774,8 @@ MainWindow::currentPaneChanged(Pane *pane)
     if (containsMainModel && !panLayerSet) {
         m_panLayer->setModel(getMainModelId());
     }
+
+    m_session.setActivePane(pane);
 }
 
 void

--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -3739,6 +3739,8 @@ MainWindow::importMoreAudio()
         return;
     }
 
+    // Add the new audio in a new pane in penultimate position
+    
     int paneCountBefore = m_paneStack->getPaneCount();
     int addAtIndex = paneCountBefore - 1;
     

--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -224,8 +224,9 @@ MainWindow::MainWindow(AudioMode audioMode, MIDIMode midiMode, bool withOSCSuppo
     SVDEBUG << "MainWindow: Creating main user interface layout" << endl;
 
     // For Piano Precision, we want to constrain playback to selection
-    // by default
+    // by default, and we don't want to play multiple recordings at once
     m_viewManager->setPlaySelectionMode(true);
+    m_viewManager->setPlaySoloMode(true);
 
     QFrame *frame = new QFrame;
     setCentralWidget(frame);

--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -3747,14 +3747,18 @@ MainWindow::importMoreAudio()
     AddPaneCommand *command = new AddPaneCommand(this, addAtIndex);
     CommandHistory::getInstance()->addCommand(command);
 
+    Pane *pane = command->getPane();
+    
     if (openAudio(path, ReplaceCurrentPane) == FileOpenFailed) {
         emit hideSplash();
-        RemovePaneCommand *rcommand = new RemovePaneCommand
-            (this, command->getPane());
+        RemovePaneCommand *rcommand = new RemovePaneCommand(this, pane);
         CommandHistory::getInstance()->addCommand(rcommand);
         QMessageBox::critical(this, tr("Failed to open file"),
                               tr("<b>File open failed</b><p>Audio file \"%1\" could not be opened").arg(path));
+        return;
     }
+
+    m_session.addFurtherAudioPane(pane);
 }
 
 void

--- a/main/ScoreWidget.cpp
+++ b/main/ScoreWidget.cpp
@@ -33,7 +33,7 @@
 
 #include "vrvtrim.h"
 
-#define DEBUG_SCORE_WIDGET 1
+//#define DEBUG_SCORE_WIDGET 1
 //#define DEBUG_EVENT_FINDING 1
 
 static QColor navigateHighlightColour("#59c4df");

--- a/main/Session.h
+++ b/main/Session.h
@@ -115,11 +115,8 @@ private:
     sv::sv_frame_t m_partialAlignmentAudioStart;
     sv::sv_frame_t m_partialAlignmentAudioEnd;
 
-    sv::TimeInstantLayer *m_displayedOnsetsLayer; // An alias for one of:
-    sv::TimeInstantLayer *m_acceptedOnsetsLayer;
     sv::TimeInstantLayer *m_pendingOnsetsLayer;
-    bool m_awaitingOnsetsLayer;
-    sv::ModelId m_awaitingFromAudioModel;
+    sv::ModelId m_audioModelForPendingOnsets;
     
     sv::TimeValueLayer *m_tempoLayer;
 
@@ -128,6 +125,7 @@ private:
     sv::ModelId getActiveAudioModel();
     sv::ModelId getAudioModelFromPane(sv::Pane *);
     sv::Pane *getAudioPaneForAudioModel(sv::ModelId);
+    sv::TimeInstantLayer *getOnsetsLayerFromPane(sv::Pane *);
     
     void setOnsetsLayerProperties(sv::TimeInstantLayer *);
     void alignmentComplete();

--- a/main/Session.h
+++ b/main/Session.h
@@ -66,6 +66,8 @@ public slots:
     
     void setMainModel(sv::ModelId modelId, QString scoreId);
 
+    void setActivePane(sv::Pane *);
+    
     void setAlignmentTransformId(sv::TransformId transformId);
     
     void beginAlignment();
@@ -107,21 +109,25 @@ private:
 
     std::vector<sv::Pane *> m_audioPanes;
     sv::Pane *m_featurePane;
+    sv::Pane *m_activePane; // an alias for one of the panes, or null
     sv::Layer *m_timeRulerLayer;
 
     sv::sv_frame_t m_partialAlignmentAudioStart;
     sv::sv_frame_t m_partialAlignmentAudioEnd;
-    
+
     sv::TimeInstantLayer *m_displayedOnsetsLayer; // An alias for one of:
     sv::TimeInstantLayer *m_acceptedOnsetsLayer;
     sv::TimeInstantLayer *m_pendingOnsetsLayer;
     bool m_awaitingOnsetsLayer;
+    sv::ModelId m_awaitingFromAudioModel;
     
     sv::TimeValueLayer *m_tempoLayer;
 
     bool m_inEditMode;
 
+    sv::ModelId getActiveAudioModel();
     sv::ModelId getAudioModelFromPane(sv::Pane *);
+    sv::Pane *getAudioPaneForAudioModel(sv::ModelId);
     
     void setOnsetsLayerProperties(sv::TimeInstantLayer *);
     void alignmentComplete();

--- a/main/Session.h
+++ b/main/Session.h
@@ -60,7 +60,7 @@ public slots:
                      sv::Pane *featurePane,
                      sv::Layer *timeRuler);
 
-    void addAudioPane(sv::Pane *audioPane);
+    void addFurtherAudioPane(sv::Pane *audioPane);
     
     void unsetDocument();
     
@@ -108,8 +108,6 @@ private:
     std::vector<sv::Pane *> m_audioPanes;
     sv::Pane *m_featurePane;
     sv::Layer *m_timeRulerLayer;
-    sv::WaveformLayer *m_waveformLayer;
-    sv::SpectrogramLayer *m_spectrogramLayer;
 
     sv::sv_frame_t m_partialAlignmentAudioStart;
     sv::sv_frame_t m_partialAlignmentAudioEnd;
@@ -122,6 +120,8 @@ private:
     sv::TimeValueLayer *m_tempoLayer;
 
     bool m_inEditMode;
+
+    sv::ModelId getAudioModelFromPane(sv::Pane *);
     
     void setOnsetsLayerProperties(sv::TimeInstantLayer *);
     void alignmentComplete();

--- a/main/Session.h
+++ b/main/Session.h
@@ -125,7 +125,13 @@ private:
     sv::ModelId getActiveAudioModel();
     sv::ModelId getAudioModelFromPane(sv::Pane *);
     sv::Pane *getAudioPaneForAudioModel(sv::ModelId);
-    sv::TimeInstantLayer *getOnsetsLayerFromPane(sv::Pane *);
+
+    enum class OnsetsLayerSelection {
+        PermitPendingOnsets,
+        ExcludePendingOnsets
+    };
+    sv::TimeInstantLayer *getOnsetsLayerFromPane(sv::Pane *,
+                                                 OnsetsLayerSelection);
     
     void setOnsetsLayerProperties(sv::TimeInstantLayer *);
     void alignmentComplete();

--- a/main/Session.h
+++ b/main/Session.h
@@ -56,10 +56,12 @@ public:
 
 public slots:
     void setDocument(sv::Document *,
-                     sv::Pane *topPane,
-                     sv::Pane *bottomPane,
+                     sv::Pane *topAudioPane,
+                     sv::Pane *featurePane,
                      sv::Layer *timeRuler);
 
+    void addAudioPane(sv::Pane *audioPane);
+    
     void unsetDocument();
     
     void setMainModel(sv::ModelId modelId, QString scoreId);
@@ -103,8 +105,8 @@ private:
     sv::ModelId m_mainModel;
     sv::TransformId m_alignmentTransformId;
 
-    sv::Pane *m_topPane;
-    sv::Pane *m_bottomPane;
+    std::vector<sv::Pane *> m_audioPanes;
+    sv::Pane *m_featurePane;
     sv::Layer *m_timeRulerLayer;
     sv::WaveformLayer *m_waveformLayer;
     sv::SpectrogramLayer *m_spectrogramLayer;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -430,6 +430,12 @@ main(int argc, char **argv)
     settings.endGroup();
 
     settings.beginGroup("Preferences");
+    if (!settings.contains("resample-on-load")) {
+        settings.setValue("resample-on-load", true);
+    }
+    settings.endGroup();
+
+    settings.beginGroup("Preferences");
     if (showSplash) {
         if (!settings.value("show-splash", true).toBool()) {
             showSplash = false;

--- a/repoint-lock.json
+++ b/repoint-lock.json
@@ -7,10 +7,10 @@
       "pin": "9a6763ad2867f9f72ed0a86a3458b3cb1bc10a87"
     },
     "svgui": {
-      "pin": "2796d24d9e1918d3ed12057f801ca07c9c1032a3"
+      "pin": "4534b055067b313157aaa31db3d3ce876f7fc086"
     },
     "svapp": {
-      "pin": "f51a1690f3f92e2421916d39a3385d49214e60c6"
+      "pin": "6e1aa0359731cd03b3ff5cd7f1a1a9d349230327"
     },
     "checker": {
       "pin": "fae540cf4a79ac5ed5a4d4dc0df680b1acbe8628"


### PR DESCRIPTION
This adds basic support for further recordings beyond the first. Use File -> Open Another Recording... to add a second or subsequent recording.

Each recording has one pane, with the spectrogram and (if aligned) onsets; the final, bottom pane with the waveform and tempo curve currently reflects the content of the first recording.

All of the usual functions (full and partial audio-to-score alignment, score following etc) should work just as before, except that now they all act on whichever recording has its pane activated (i.e. has the black bar down its left side).

There is no use of audio-to-audio alignment here yet.
