### PR TITLE
Further fixes to onset ticking sound

### DIFF
--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -5982,17 +5982,22 @@ MainWindow::currentPaneChanged(Pane *pane)
 
     if (m_viewManager->getPlaySoloMode()) {
 
+        // We want to solo only the active audio model for the pane
+        // (in case there is more than one audio model here), as well
+        // as any non-audio models that are on top of it
+        
         ModelId activeModel = m_session.getActiveAudioModel();
         std::set<ModelId> soloModels;
         soloModels.insert(activeModel);
     
-        for (int i = 0; i < pane->getLayerCount(); ++i ) {
+        for (int i = pane->getLayerCount(); i > 0; ) {
+            --i;
             Layer *layer = pane->getLayer(i);
             ModelId modelId = layer->getModel();
-            auto model = ModelById::get(modelId);
-            if (model && model->getSourceModel() == activeModel) {
-                soloModels.insert(modelId);
+            if (modelId == activeModel) {
+                break;
             }
+            soloModels.insert(modelId);
         }
 
         m_viewManager->setPlaybackModel(activeModel);

--- a/repoint-lock.json
+++ b/repoint-lock.json
@@ -10,7 +10,7 @@
       "pin": "810bb87b5e7281dba738066e035aaccd01ce42aa"
     },
     "svapp": {
-      "pin": "d77c64ac28403e9fd909256ec9a006954f61a1b5"
+      "pin": "70bf9c6b9b1a71a68173de0728f67c47342dafaa"
     },
     "checker": {
       "pin": "fae540cf4a79ac5ed5a4d4dc0df680b1acbe8628"
@@ -57,14 +57,14 @@
     "dummy-score-aligner": {
       "pin": "489aba2ef9411dea17eb407aa7332ddc8152f960"
     },
-    "tuning-difference": {
-      "pin": "5216a8858e8931c0d707192366488303bfb5a169"
-    },
     "match": {
       "pin": "9e0c3be2be4f97e5d91e888a48f6e0ad77edd2f4"
     },
     "constant-q-cpp": {
       "pin": "7ac84048e3e43c433d88e12d221af15e50f41591"
+    },
+    "tuning-difference": {
+      "pin": "5216a8858e8931c0d707192366488303bfb5a169"
     }
   }
 }


### PR DESCRIPTION
Ensure all non-audio layers on top of the audio layer in a pane are played when in solo mode; and update the set of solo models when a layer is added to a pane.

Note that part of this fix is in a subrepo, so please re-run `./repoint install` to test.
