### PR TITLE
Use Fraction to reduce synthetic label to simplest form

### DIFF
--- a/deploy/win64/wxs.in
+++ b/deploy/win64/wxs.in
@@ -204,6 +204,22 @@
                 Name="msvcp140.dll"
                 Source="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Redist\MSVC\@REDIST_VER@\x64\Microsoft.VC142.CRT\msvcp140.DLL"/>
             <File
+                Id="msvcp140_1"
+                Name="msvcp140_1.dll"
+                Source="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Redist\MSVC\@REDIST_VER@\x64\Microsoft.VC142.CRT\msvcp140_1.DLL"/>
+            <File
+                Id="msvcp140_2"
+                Name="msvcp140_2.dll"
+                Source="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Redist\MSVC\@REDIST_VER@\x64\Microsoft.VC142.CRT\msvcp140_2.DLL"/>
+            <File
+                Id="msvcp140_atomic_wait"
+                Name="msvcp140_atomic_wait.dll"
+                Source="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Redist\MSVC\@REDIST_VER@\x64\Microsoft.VC142.CRT\msvcp140_atomic_wait.DLL"/>
+            <File
+                Id="msvcp140_codecvt_ids"
+                Name="msvcp140_codecvt_ids.dll"
+                Source="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Redist\MSVC\@REDIST_VER@\x64\Microsoft.VC142.CRT\msvcp140_codecvt_ids.DLL"/>
+            <File
                 Id="vccorlib140"
                 Name="vccorlib140.dll"
                 Source="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Redist\MSVC\@REDIST_VER@\x64\Microsoft.VC142.CRT\vccorlib140.DLL"/>
@@ -272,6 +288,18 @@
                   Id="msvcp140h"
                   Name="msvcp140.dll"
                   Source="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Redist\MSVC\@REDIST_VER@\x64\Microsoft.VC142.CRT\msvcp140.DLL"/>
+              <File
+                  Id="msvcp140_1h"
+                  Name="msvcp140_1.dll"
+                  Source="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Redist\MSVC\@REDIST_VER@\x64\Microsoft.VC142.CRT\msvcp140_1.DLL"/>
+              <File
+                  Id="msvcp140_2h"
+                  Name="msvcp140_2.dll"
+                  Source="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Redist\MSVC\@REDIST_VER@\x64\Microsoft.VC142.CRT\msvcp140_2.DLL"/>
+              <File
+                  Id="msvcp140_codecvt_idsh"
+                  Name="msvcp140_codecvt_ids.dll"
+                  Source="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Redist\MSVC\@REDIST_VER@\x64\Microsoft.VC142.CRT\msvcp140_codecvt_ids.DLL"/>
               <File
                   Id="vccorlib140h"
                   Name="vccorlib140.dll"

--- a/main/TempoCurveWidget.cpp
+++ b/main/TempoCurveWidget.cpp
@@ -670,8 +670,12 @@ TempoCurveWidget::extractCurve(ModelId tempoCurveModelId) const
                 }
 
                 double syntheticValue = beatDuration / acc;
+                Fraction frac(beat, denom); // To reduce to simplest form
                 QString syntheticLabel =
-                    QString("%1+%2/%3").arg(bar).arg(beat).arg(denom);
+                    QString("%1+%2/%3")
+                    .arg(bar)
+                    .arg(frac.numerator)
+                    .arg(frac.denominator);
 
 #ifdef DEBUG_TEMPO_CURVE_WIDGET
                 SVDEBUG << "TempoCurveWidget::extractCurve: finalised acc with "
@@ -977,6 +981,9 @@ TempoCurveWidget::mouseMoveEvent(QMouseEvent *e)
 
     if (!m_clickedInRange) {
         if (identifyClosePoint(e->pos())) {
+#ifdef DEBUG_TEMPO_CURVE_WIDGET
+            SVDEBUG << "TempoCurveWidget::mouseMoveEvent: Found close point, asking to highlight label \"" << m_closeLabel << "\"" << endl;
+#endif
             emit highlightLabel(m_closeLabel);
             update();
         }


### PR DESCRIPTION
Fixes failure of the score to update when highlighting or selecting events on the tempo curve in beat mode.